### PR TITLE
refactor: use parking_lot::RwLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tokio-io = "0.1"
 nom = "3.2"
 cookie-factory = "0.2.2"
 get_if_addrs = "0.5"
+parking_lot = "0.5"
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ extern crate quickcheck;
 extern crate tokio;
 extern crate tokio_io;
 extern crate get_if_addrs;
+extern crate parking_lot;
 
 
 // TODO: refactor macros


### PR DESCRIPTION
parking_lot::RwLock has one good property:

> RwLock uses a task-fair locking policy, which avoids reader and writer starvation, whereas the standard library version makes no guarantees.

It will be important for onion - no matter how many read locks we have we want to force refresh key when time is come.