### PR TITLE
separate ClientData from DhtNode

### DIFF
--- a/src/toxcore/dht/dht_node.rs
+++ b/src/toxcore/dht/dht_node.rs
@@ -27,7 +27,6 @@ Here, GOOD node is the node responded within 162 seconds, BAD node is the node n
 */
 
 use std::net::SocketAddr;
-use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use std::cmp::Ordering;
 use toxcore::crypto_core::*;
@@ -39,9 +38,6 @@ Good means it is online and responded within 162 seconds
 Bad means it is probably offline and did not responded for over 162 seconds
 When new peer is added to bucket, Bad status node should be replace.
 If there are no Bad nodes in bucket, node which is farther than peer is replaced.
-
-Manage ping_id.
-Generate ping_id on request packet, check ping_id on response packet.
 */
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum NodeStatus {
@@ -93,8 +89,6 @@ we should make decision to add new node to close node list, or not.
 the PK's distance and status of node help making decision.
 Bad node have higher priority than Good node.
 If both node is Good node, then we compare PK's distance.
-
-Generate ping_id on request packet, check ping_id on response packet.
 */
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DhtNode {
@@ -102,12 +96,8 @@ pub struct DhtNode {
     pub saddr: SocketAddr,
     /// Public Key of the node.
     pub pk: PublicKey,
-    /// hash of ping_ids to check PingResponse is correct
-    pub ping_hash: HashMap<u64, Instant>,
     /// last received ping/nodes-response time
     pub last_resp_time: Instant,
-    /// last sent ping-req time
-    pub last_ping_req_time: Instant,
 }
 
 impl DhtNode {
@@ -116,9 +106,7 @@ impl DhtNode {
         DhtNode {
             pk: pn.pk,
             saddr: pn.saddr,
-            ping_hash: HashMap::new(),
             last_resp_time: Instant::now(),
-            last_ping_req_time: Instant::now(),
         }
     }
 
@@ -130,53 +118,6 @@ impl DhtNode {
             NodeStatus::Good
         }
     }
-
-    /// set new random ping id to the client and return it
-    fn generate_ping_id(&mut self) -> u64 {
-        loop {
-            let ping_id = random_u64();
-            if ping_id != 0 && !self.ping_hash.contains_key(&ping_id) {
-                return ping_id;
-            }
-        }
-    }
-
-    /// clear timed out ping_id
-    pub fn clear_timedout_pings(&mut self, timeout: Duration) {
-        self.ping_hash.retain(|&_ping_id, &mut time|
-            time.elapsed() <= timeout);
-    }
-
-    /// Add a Ping Hash Entry and return a new ping_id.
-    pub fn insert_new_ping_id(&mut self) -> u64 {
-        let ping_id = self.generate_ping_id();
-        self.ping_hash.insert(ping_id, Instant::now());
-
-        ping_id
-    }
-
-    /// Check if ping_id is valid and not timed out.
-    pub fn check_ping_id(&mut self, ping_id: u64, timeout: Duration) -> bool {
-        if ping_id == 0 {
-            debug!("Given ping_id is 0");
-            return false
-        }
-
-        let time_ping_sent = match self.ping_hash.remove(&ping_id) {
-            None => {
-                debug!("Given ping_id don't exist in PingHash");
-                return false
-            },
-            Some(time) => time,
-        };
-
-        if time_ping_sent.elapsed() > timeout {
-            debug!("Given ping_id is timed out");
-            return false
-        }
-
-        true
-    }
 }
 
 #[cfg(test)]
@@ -185,74 +126,13 @@ mod tests {
     use quickcheck::quickcheck;
 
     #[test]
-    fn client_data_clonable() {
+    fn dht_node_clonable() {
         let pn = PackedNode {
             pk: gen_keypair().0,
             saddr: "127.0.0.1:33445".parse().unwrap(),
         };
-        let client = DhtNode::new(pn);
-        let _ = client.clone();
-    }
-
-    #[test]
-    fn client_data_insert_new_ping_id_test() {
-        let pn = PackedNode {
-            pk: gen_keypair().0,
-            saddr: "127.0.0.1:33445".parse().unwrap(),
-        };
-        let mut client = DhtNode::new(pn);
-
-        let ping_id = client.insert_new_ping_id();
-
-        assert!(client.ping_hash.contains_key(&ping_id));
-    }
-
-    #[test]
-    fn client_data_check_ping_id_test() {
-        let pn = PackedNode {
-            pk: gen_keypair().0,
-            saddr: "127.0.0.1:33445".parse().unwrap(),
-        };
-        let mut client = DhtNode::new(pn);
-
-        let ping_id = client.insert_new_ping_id();
-
-        let dur = Duration::from_secs(1);
-        // give incorrect ping_id
-        assert!(!client.check_ping_id(0, dur));
-        assert!(!client.check_ping_id(ping_id + 1, dur));
-
-        // Though ping_id is correct, it is timed-out
-        let dur = Duration::from_secs(0);
-        assert!(!client.check_ping_id(ping_id, dur));
-
-        // Now, timeout duration is 5 seconds
-        let dur = Duration::from_secs(5);
-
-        let ping_id = client.insert_new_ping_id();
-        assert!(client.check_ping_id(ping_id, dur));
-    }
-
-    #[test]
-    fn client_data_clear_timedout_pings_test() {
-        let pn = PackedNode {
-            pk: gen_keypair().0,
-            saddr: "127.0.0.1:33445".parse().unwrap(),
-        };
-        let mut client = DhtNode::new(pn);
-
-        // ping_id should be removed
-        let ping_id = client.insert_new_ping_id();
-        let dur = Duration::from_secs(0);
-        client.clear_timedout_pings(dur);
-        let dur = Duration::from_secs(1);
-        assert!(!client.check_ping_id(ping_id, dur));
-
-        // ping_id should remain
-        let ping_id = client.insert_new_ping_id();
-        let dur = Duration::from_secs(1);
-        client.clear_timedout_pings(dur);
-        assert!(client.check_ping_id(ping_id, dur));
+        let dht_node = DhtNode::new(pn);
+        let _ = dht_node.clone();
     }
 
     #[test]
@@ -267,14 +147,13 @@ mod tests {
             assert_eq!(true, bucket.try_add(&pk, &n3));
             assert_eq!(true, bucket.try_add(&pk, &n4));
             assert_eq!(true, bucket.try_add(&pk, &n5));
+            bucket.set_bad_node_timeout(0);
             assert_eq!(true, bucket.try_add(&pk, &n6));
             assert_eq!(true, bucket.try_add(&pk, &n7));
             assert_eq!(true, bucket.try_add(&pk, &n8));
 
             // updating bucket
             assert_eq!(true, bucket.try_add(&pk, &n1));
-
-            // TODO: check whether adding a closest node will always work
         }
         quickcheck(with_nodes as fn(PackedNode, PackedNode, PackedNode, PackedNode,
                                     PackedNode, PackedNode, PackedNode, PackedNode));

--- a/src/toxcore/dht/kbucket.rs
+++ b/src/toxcore/dht/kbucket.rs
@@ -43,7 +43,6 @@ use std::cmp::{Ord, Ordering};
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 use std::convert::Into;
-use std::collections::HashMap;
 
 const BAD_NODE_TIMEOUT: u64 = 182;
 
@@ -85,9 +84,7 @@ impl Into<DhtNode> for PackedNode {
         DhtNode {
             pk: self.pk,
             saddr: self.saddr,
-            ping_hash: HashMap::new(),
             last_resp_time: Instant::now(),
-            last_ping_req_time: Instant::now(),
         }
     }
 }

--- a/src/toxcore/dht/server/client.rs
+++ b/src/toxcore/dht/server/client.rs
@@ -1,0 +1,158 @@
+/*
+    Copyright © 2017 Zetok Zalbavar <zexavexxe@gmail.com>
+    Copyright © 2018 Namsoo CHO <nscho66@gmail.com>
+
+    This file is part of Tox.
+
+    Tox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Tox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Tox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+/*!
+Manage ping_id.
+Generate ping_id on request packet, check ping_id on response packet.
+*/
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use toxcore::crypto_core::*;
+
+/// peer info.
+#[derive(Clone, Debug)]
+pub struct ClientData {
+    /// hash of ping_ids to check PingResponse is correct
+    ping_hash: HashMap<u64, Instant>,
+    /// last received ping/nodes-response time
+    pub last_resp_time: Instant,
+    /// last sent ping-req time
+    pub last_ping_req_time: Instant,
+}
+
+impl ClientData {
+    /// create ClientData object
+    pub fn new() -> ClientData {
+        ClientData {
+            ping_hash: HashMap::new(),
+            last_resp_time: Instant::now(),
+            last_ping_req_time: Instant::now(),
+        }
+    }
+    /// set new random ping id to the client and return it
+    fn generate_ping_id(&mut self) -> u64 {
+        loop {
+            let ping_id = random_u64();
+            if ping_id != 0 && !self.ping_hash.contains_key(&ping_id) {
+                return ping_id;
+            }
+        }
+    }
+
+    /// clear timed out ping_id
+    pub fn clear_timedout_pings(&mut self, timeout: Duration) {
+        self.ping_hash.retain(|&_ping_id, &mut time|
+            time.elapsed() <= timeout);
+    }
+
+    /// Add a Ping Hash Entry and return a new ping_id.
+    pub fn insert_new_ping_id(&mut self) -> u64 {
+        let ping_id = self.generate_ping_id();
+        self.ping_hash.insert(ping_id, Instant::now());
+
+        ping_id
+    }
+
+    /// Check if ping_id is valid and not timed out.
+    pub fn check_ping_id(&mut self, ping_id: u64, timeout: Duration) -> bool {
+        if ping_id == 0 {
+            debug!("Given ping_id is 0");
+            return false
+        }
+
+        let time_ping_sent = match self.ping_hash.remove(&ping_id) {
+            None => {
+                debug!("Given ping_id don't exist in PingHash");
+                return false
+            },
+            Some(time) => time,
+        };
+
+        if time_ping_sent.elapsed() > timeout {
+            debug!("Given ping_id is timed out");
+            return false
+        }
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_data_clonable() {
+        let client = ClientData::new();
+        let _ = client.clone();
+    }
+
+    #[test]
+    fn client_data_insert_new_ping_id_test() {
+        let mut client = ClientData::new();
+
+        let ping_id = client.insert_new_ping_id();
+
+        assert!(client.ping_hash.contains_key(&ping_id));
+    }
+
+    #[test]
+    fn client_data_check_ping_id_test() {
+        let mut client = ClientData::new();
+
+        let ping_id = client.insert_new_ping_id();
+
+        let dur = Duration::from_secs(1);
+        // give incorrect ping_id
+        assert!(!client.check_ping_id(0, dur));
+        assert!(!client.check_ping_id(ping_id + 1, dur));
+
+        // Though ping_id is correct, it is timed-out
+        let dur = Duration::from_secs(0);
+        assert!(!client.check_ping_id(ping_id, dur));
+
+        // Now, timeout duration is 5 seconds
+        let dur = Duration::from_secs(5);
+
+        let ping_id = client.insert_new_ping_id();
+        assert!(client.check_ping_id(ping_id, dur));
+    }
+
+    #[test]
+    fn client_data_clear_timedout_pings_test() {
+        let mut client = ClientData::new();
+
+        // ping_id should be removed
+        let ping_id = client.insert_new_ping_id();
+        let dur = Duration::from_secs(0);
+        client.clear_timedout_pings(dur);
+        let dur = Duration::from_secs(1);
+        assert!(!client.check_ping_id(ping_id, dur));        
+
+        // ping_id should remain
+        let ping_id = client.insert_new_ping_id();
+        let dur = Duration::from_secs(1);
+        client.clear_timedout_pings(dur);
+        assert!(client.check_ping_id(ping_id, dur));        
+    }
+}

--- a/src/toxcore/dht/server/client.rs
+++ b/src/toxcore/dht/server/client.rs
@@ -31,7 +31,7 @@ use toxcore::crypto_core::*;
 
 /// peer info.
 #[derive(Clone, Debug)]
-pub struct ClientData {
+pub struct PingData {
     /// hash of ping_ids to check PingResponse is correct
     ping_hash: HashMap<u64, Instant>,
     /// last received ping/nodes-response time
@@ -40,10 +40,10 @@ pub struct ClientData {
     pub last_ping_req_time: Instant,
 }
 
-impl ClientData {
-    /// create ClientData object
-    pub fn new() -> ClientData {
-        ClientData {
+impl PingData {
+    /// create PingData object
+    pub fn new() -> PingData {
+        PingData {
             ping_hash: HashMap::new(),
             last_resp_time: Instant::now(),
             last_ping_req_time: Instant::now(),
@@ -103,13 +103,13 @@ mod tests {
 
     #[test]
     fn client_data_clonable() {
-        let client = ClientData::new();
+        let client = PingData::new();
         let _ = client.clone();
     }
 
     #[test]
     fn client_data_insert_new_ping_id_test() {
-        let mut client = ClientData::new();
+        let mut client = PingData::new();
 
         let ping_id = client.insert_new_ping_id();
 
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     fn client_data_check_ping_id_test() {
-        let mut client = ClientData::new();
+        let mut client = PingData::new();
 
         let ping_id = client.insert_new_ping_id();
 
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn client_data_clear_timedout_pings_test() {
-        let mut client = ClientData::new();
+        let mut client = PingData::new();
 
         // ping_id should be removed
         let ping_id = client.insert_new_ping_id();

--- a/src/toxcore/dht/server/hole_punching.rs
+++ b/src/toxcore/dht/server/hole_punching.rs
@@ -394,10 +394,10 @@ mod tests {
 
         let ping_req_payload = ping_req.get_payload(&friend_sk).unwrap();
 
-        let peers_cache = alice.get_peers_cache();
-        let mut peers_cache = peers_cache.write();
+        let ping_map = alice.get_ping_map();
+        let mut ping_map = ping_map.write();
 
-        let client = peers_cache.get_mut(&friend_pk).unwrap();
+        let client = ping_map.get_mut(&friend_pk).unwrap();
         let dur = Duration::from_secs(PING_TIMEOUT);
 
         assert!(client.check_ping_id(ping_req_payload.id, dur));
@@ -435,10 +435,10 @@ mod tests {
 
         let ping_req_payload = ping_req.get_payload(&friend_sk).unwrap();
 
-        let peers_cache = alice.get_peers_cache();
-        let mut peers_cache = peers_cache.write();
+        let ping_map = alice.get_ping_map();
+        let mut ping_map = ping_map.write();
 
-        let client = peers_cache.get_mut(&friend_pk).unwrap();
+        let client = ping_map.get_mut(&friend_pk).unwrap();
         let dur = Duration::from_secs(PING_TIMEOUT);
 
         assert!(client.check_ping_id(ping_req_payload.id, dur));

--- a/src/toxcore/dht/server/mod.rs
+++ b/src/toxcore/dht/server/mod.rs
@@ -105,8 +105,8 @@ pub struct Server {
     pub tx: Tx,
     /// option for hole punching
     pub is_hole_punching_enabled: bool,
-    // store client object which has sent request packet to peer
-    peers_cache: Arc<RwLock<HashMap<PublicKey, ClientData>>>,
+    // store ping object which has sent request packet to peer
+    ping_map: Arc<RwLock<HashMap<PublicKey, PingData>>>,
     // Close List (contains nodes close to own DHT PK)
     close_nodes: Arc<RwLock<Kbucket>>,
     // symmetric key used for onion return encryption
@@ -142,7 +142,7 @@ pub struct Server {
 /// Struct for grouping parameters to Server's main loop
 #[derive(Copy, Clone, Default)]
 pub struct ConfigArgs {
-    /// timeout in seconds for remove clients in peers_cache
+    /// timeout in seconds for remove clients in ping_map
     pub kill_node_timeout: u64,
     /// timeout in seconds for PingRequest and NodesRequest
     pub ping_timeout: u64,
@@ -167,7 +167,7 @@ impl Server {
             pk,
             tx,
             is_hole_punching_enabled: true,
-            peers_cache: Arc::new(RwLock::new(HashMap::new())),
+            ping_map: Arc::new(RwLock::new(HashMap::new())),
             close_nodes: Arc::new(RwLock::new(Kbucket::new(&pk))),
             onion_symmetric_key: Arc::new(RwLock::new(secretbox::gen_key())),
             onion_announce: Arc::new(RwLock::new(OnionAnnounce::new(pk))),
@@ -183,9 +183,9 @@ impl Server {
         }
     }
 
-    /// return peers_cache member variable
-    pub fn get_peers_cache(&self) -> &Arc<RwLock<HashMap<PublicKey, ClientData>>> {
-        &self.peers_cache
+    /// return ping_map member variable
+    pub fn get_ping_map(&self) -> &Arc<RwLock<HashMap<PublicKey, PingData>>> {
+        &self.ping_map
     }
 
     /// add friend
@@ -254,12 +254,12 @@ impl Server {
         let mut bootstrap_nodes = Bucket::new(None);
         mem::swap(&mut bootstrap_nodes, self.bootstrap_nodes.write().deref_mut());
 
-        let mut peers_cache = self.peers_cache.write();
+        let mut ping_map = self.ping_map.write();
 
         let bootstrap_nodes = bootstrap_nodes.to_packed_node();
         let nodes_sender = bootstrap_nodes.iter()
             .map(|node| {
-                let client = peers_cache.entry(node.pk).or_insert_with(ClientData::new);
+                let client = ping_map.entry(node.pk).or_insert_with(PingData::new);
 
                 self.send_nodes_req(*node, self.pk, client)
             });
@@ -275,8 +275,8 @@ impl Server {
 
         let nodes_sender = close_nodes.iter()
             .map(|node| {
-                let mut peers_cache = self.peers_cache.write();
-                let client = peers_cache.entry(node.pk).or_insert_with(ClientData::new);
+                let mut ping_map = self.ping_map.write();
+                let client = ping_map.entry(node.pk).or_insert_with(PingData::new);
                 (node, client.clone())
             })
             .filter(|&(_node, ref client)|
@@ -285,7 +285,7 @@ impl Server {
             .map(|(node, mut client)| {
                 client.last_ping_req_time = Instant::now();
                 let res = self.send_nodes_req(node, self.pk, &mut client);
-                self.peers_cache.write().deref_mut().insert(node.pk, client);
+                self.ping_map.write().deref_mut().insert(node.pk, client);
                 res
             });
 
@@ -297,11 +297,11 @@ impl Server {
     // every 20 seconds DHT node send NodesRequest to random node which is in close list
     fn send_nodes_req_random(&self, bad_node_timeout: Duration, nodes_req_interval: Duration) -> IoFuture<()> {
         let close_nodes = self.close_nodes.read();
-        let mut peers_cache = self.peers_cache.write();
+        let mut ping_map = self.ping_map.write();
 
         let good_nodes = close_nodes.iter()
             .filter(|&node| {
-                let client = peers_cache.entry(node.pk).or_insert_with(ClientData::new);
+                let client = ping_map.entry(node.pk).or_insert_with(PingData::new);
                 client.last_resp_time.elapsed() < bad_node_timeout
             }).collect::<Vec<PackedNode>>();
 
@@ -319,7 +319,7 @@ impl Server {
             let random_node = good_nodes[random_node];
 
 
-            let client = peers_cache.entry(random_node.pk).or_insert_with(ClientData::new);
+            let client = ping_map.entry(random_node.pk).or_insert_with(PingData::new);
 
             let res = self.send_nodes_req(random_node, self.pk, client);
 
@@ -334,17 +334,17 @@ impl Server {
     // remove timed-out clients,
     // close_nodes entry should be remain even if offline timed out, so after online, server try to ping again.
     fn remove_timedout_clients(&self, timeout: Duration) -> IoFuture<()> {
-        let mut peers_cache = self.peers_cache.write();
+        let mut ping_map = self.ping_map.write();
 
-        peers_cache.retain(|&_pk, ref client|
+        ping_map.retain(|&_pk, ref client|
             client.last_resp_time.elapsed() <= timeout);
         Box::new(future::ok(()))
     }
 
     // remove PING_TIMEOUT timed out ping_ids of PingHash
     fn remove_timedout_ping_ids(&self, timeout: Duration) -> IoFuture<()> {
-        let mut peers_cache = self.peers_cache.write();
-        peers_cache.iter_mut()
+        let mut ping_map = self.ping_map.write();
+        ping_map.iter_mut()
             .for_each(|(_pk, client)|
                 client.clear_timedout_pings(timeout)
             );
@@ -366,8 +366,8 @@ impl Server {
 
     /// Send PingRequest to node
     pub fn send_ping_req(&self, node: &PackedNode) -> IoFuture<()> {
-        let mut peers_cache = self.peers_cache.write();
-        let client = peers_cache.entry(node.pk).or_insert_with(ClientData::new);
+        let mut ping_map = self.ping_map.write();
+        let client = ping_map.entry(node.pk).or_insert_with(PingData::new);
 
         let payload = PingRequestPayload {
             id: client.insert_new_ping_id(),
@@ -381,7 +381,7 @@ impl Server {
     }
 
     /// Send NodesRequest to peer
-    pub fn send_nodes_req(&self, target_peer: PackedNode, search_pk: PublicKey, client: &mut ClientData) -> IoFuture<()> {
+    pub fn send_nodes_req(&self, target_peer: PackedNode, search_pk: PublicKey, client: &mut PingData) -> IoFuture<()> {
         // Check if packet is going to be sent to ourself.
         if self.pk == target_peer.pk {
             return Box::new(
@@ -585,7 +585,7 @@ impl Server {
     handle received PingResponse packet. If ping_id is correct, try_add peer to close_nodes.
     */
     fn handle_ping_resp(&self, packet: PingResponse) -> IoFuture<()> {
-        let mut peers_cache = self.peers_cache.write();
+        let mut ping_map = self.ping_map.write();
         let payload = packet.get_payload(&self.sk);
         let payload = match payload {
             Err(e) => return Box::new(future::err(e)),
@@ -599,7 +599,7 @@ impl Server {
             )))
         }
 
-        let client = peers_cache.get_mut(&packet.pk);
+        let client = ping_map.get_mut(&packet.pk);
         let client = match client {
             None => {
                 return Box::new( future::err(
@@ -648,7 +648,7 @@ impl Server {
     handle received NodesResponse from peer.
     */
     fn handle_nodes_resp(&self, packet: NodesResponse) -> IoFuture<()> {
-        let mut peers_cache = self.peers_cache.write();
+        let mut ping_map = self.ping_map.write();
 
         let payload = packet.get_payload(&self.sk);
         let payload = match payload {
@@ -656,7 +656,7 @@ impl Server {
             Ok(payload) => payload,
         };
 
-        let client = peers_cache.get_mut(&packet.pk);
+        let client = ping_map.get_mut(&packet.pk);
         let client = match client {
             None => {
                 return Box::new( future::err(
@@ -673,7 +673,7 @@ impl Server {
         let timeout_dur = Duration::from_secs(PING_TIMEOUT);
         if client.check_ping_id(payload.id, timeout_dur) {
             for node in &payload.nodes {
-                // not worried about removing evicted nodes from peers_cache
+                // not worried about removing evicted nodes from ping_map
                 // they will be removed by timeout eventually since we won't
                 // ping them anymore
                 close_nodes.try_add(node);
@@ -830,9 +830,9 @@ impl Server {
             pk: packet.pk,
         };
 
-        let mut peers_cache = self.peers_cache.write();
-        let peers_cache = peers_cache.deref_mut();
-        let client = peers_cache.entry(packet.pk).or_insert_with(ClientData::new);
+        let mut ping_map = self.ping_map.write();
+        let ping_map = ping_map.deref_mut();
+        let client = ping_map.entry(packet.pk).or_insert_with(PingData::new);
 
         self.send_nodes_req(target_node, self.pk, client)
     }
@@ -1171,9 +1171,9 @@ mod tests {
         (alice, precomp, bob_pk, bob_sk, rx, addr)
     }
 
-    fn add_to_peers_cache(alice: &Server, pk: PublicKey, client: ClientData) {
-        let mut peers_cache = alice.peers_cache.write();
-        peers_cache.insert(pk, client);
+    fn add_to_ping_map(alice: &Server, pk: PublicKey, client: PingData) {
+        let mut ping_map = alice.ping_map.write();
+        ping_map.insert(pk, client);
     }
 
     #[test]
@@ -1193,10 +1193,10 @@ mod tests {
     }
 
     #[test]
-    fn server_get_peers_cache_test() {
+    fn server_get_ping_map_test() {
         let (alice, _precomp, _bob_pk, _bob_sk, _rx, _addr) = create_node();
 
-        let _ = alice.get_peers_cache();
+        let _ = alice.get_ping_map();
     }
 
     #[test]
@@ -1258,12 +1258,12 @@ mod tests {
 
         // handle ping response, request from bob peer
         // success case
-        let mut client = ClientData::new();
+        let mut client = PingData::new();
         let ping_id = client.insert_new_ping_id();
         let resp_payload = PingResponsePayload { id: ping_id };
         let ping_resp = DhtPacket::PingResponse(PingResponse::new(&precomp, &bob_pk, resp_payload));
 
-        add_to_peers_cache(&alice, bob_pk, client);
+        add_to_ping_map(&alice, bob_pk, client);
 
         assert!(alice.handle_packet(ping_resp, addr).wait().is_ok());
     }
@@ -1273,12 +1273,12 @@ mod tests {
         let (alice, precomp, bob_pk, _bob_sk, _rx, addr) = create_node();
 
         // wrong PK, decrypt fail
-        let mut client = ClientData::new();
+        let mut client = PingData::new();
         let ping_id = client.insert_new_ping_id();
         let prs = PingResponsePayload { id: ping_id };
         let ping_resp = DhtPacket::PingResponse(PingResponse::new(&precomp, &alice.pk, prs));
 
-        add_to_peers_cache(&alice, bob_pk, client);
+        add_to_ping_map(&alice, bob_pk, client);
 
         assert!(alice.handle_packet(ping_resp, addr).wait().is_err());
     }
@@ -1291,8 +1291,8 @@ mod tests {
         let prs = PingResponsePayload { id: 0 };
         let ping_resp = DhtPacket::PingResponse(PingResponse::new(&precomp, &bob_pk, prs));
 
-        let client = ClientData::new();
-        add_to_peers_cache(&alice, bob_pk, client);
+        let client = PingData::new();
+        add_to_ping_map(&alice, bob_pk, client);
 
         assert!(alice.handle_packet(ping_resp, addr).wait().is_err());
     }
@@ -1302,12 +1302,12 @@ mod tests {
         let (alice, precomp, bob_pk, _bob_sk, _rx, addr) = create_node();
 
         // incorrect ping_id, fail
-        let mut client = ClientData::new();
+        let mut client = PingData::new();
         let ping_id = client.insert_new_ping_id();
         let prs = PingResponsePayload { id: ping_id + 1 };
         let ping_resp = DhtPacket::PingResponse(PingResponse::new(&precomp, &bob_pk, prs));
 
-        add_to_peers_cache(&alice, bob_pk, client);
+        add_to_ping_map(&alice, bob_pk, client);
 
         assert!(alice.handle_packet(ping_resp, addr).wait().is_err());
     }
@@ -1358,12 +1358,12 @@ mod tests {
         let node = vec![PackedNode::new(false, addr, &bob_pk)];
 
         // handle nodes response, request from bob peer
-        let mut client = ClientData::new();
+        let mut client = PingData::new();
         let ping_id = client.insert_new_ping_id();
         let resp_payload = NodesResponsePayload { nodes: node, id: ping_id };
         let nodes_resp = DhtPacket::NodesResponse(NodesResponse::new(&precomp, &bob_pk, resp_payload.clone()));
 
-        add_to_peers_cache(&alice, bob_pk, client);
+        add_to_ping_map(&alice, bob_pk, client);
 
         assert!(alice.handle_packet(nodes_resp, addr).wait().is_ok());
 
@@ -1400,8 +1400,8 @@ mod tests {
         ], id: 0 };
         let nodes_resp = DhtPacket::NodesResponse(NodesResponse::new(&precomp, &bob_pk, resp_payload));
 
-        let client = ClientData::new();
-        add_to_peers_cache(&alice, bob_pk, client);
+        let client = PingData::new();
+        add_to_ping_map(&alice, bob_pk, client);
 
         assert!(alice.handle_packet(nodes_resp, addr).wait().is_err());
     }
@@ -1411,14 +1411,14 @@ mod tests {
         let (alice, precomp, bob_pk, _bob_sk, _rx, addr) = create_node();
 
         // incorrect ping_id
-        let mut client = ClientData::new();
+        let mut client = PingData::new();
         let ping_id = client.insert_new_ping_id();
         let resp_payload = NodesResponsePayload { nodes: vec![
             PackedNode::new(false, SocketAddr::V4("127.0.0.1:12345".parse().unwrap()), &gen_keypair().0)
         ], id: ping_id + 1 };
         let nodes_resp = DhtPacket::NodesResponse(NodesResponse::new(&precomp, &bob_pk, resp_payload));
 
-        add_to_peers_cache(&alice, bob_pk, client);
+        add_to_ping_map(&alice, bob_pk, client);
 
         assert!(alice.handle_packet(nodes_resp, addr).wait().is_err());
     }
@@ -1603,8 +1603,8 @@ mod tests {
         let nat_payload = DhtRequestPayload::NatPingResponse(nat_res);
         let dht_req = DhtPacket::DhtRequest(DhtRequest::new(&precomp, &alice.pk, &bob_pk, nat_payload));
 
-        let client = ClientData::new();
-        add_to_peers_cache(&alice, bob_pk, client);
+        let client = PingData::new();
+        add_to_ping_map(&alice, bob_pk, client);
 
         assert!(alice.handle_packet(dht_req, addr).wait().is_ok());
     }
@@ -1618,8 +1618,8 @@ mod tests {
         let nat_payload = DhtRequestPayload::NatPingResponse(nat_res);
         let dht_req = DhtPacket::DhtRequest(DhtRequest::new(&precomp, &alice.pk, &bob_pk, nat_payload));
 
-        let client = ClientData::new();
-        add_to_peers_cache(&alice, bob_pk, client);
+        let client = PingData::new();
+        add_to_ping_map(&alice, bob_pk, client);
 
         assert!(alice.handle_packet(dht_req, addr).wait().is_err());
     }
@@ -1629,13 +1629,13 @@ mod tests {
         let (alice, precomp, bob_pk, _bob_sk, _rx, addr) = create_node();
 
         // error case, incorrect ping_id
-        let mut client = ClientData::new();
+        let mut client = PingData::new();
         let ping_id = client.insert_new_ping_id();
         let nat_res = NatPingResponse { id: ping_id + 1 };
         let nat_payload = DhtRequestPayload::NatPingResponse(nat_res);
         let dht_req = DhtPacket::DhtRequest(DhtRequest::new(&precomp, &alice.pk, &bob_pk, nat_payload));
 
-        add_to_peers_cache(&alice, bob_pk, client);
+        add_to_ping_map(&alice, bob_pk, client);
 
         assert!(alice.handle_packet(dht_req, addr).wait().is_err());
     }
@@ -2337,19 +2337,19 @@ mod tests {
 
         alice.send_pings().wait().unwrap();
 
-        let mut peers_cache = alice.peers_cache.write();
+        let mut ping_map = alice.ping_map.write();
         rx.take(2).map(|received| {
             let (packet, addr) = received;
             let mut buf = [0; 512];
             let (_, size) = packet.to_bytes((&mut buf, 0)).unwrap();
             let (_, ping_req) = PingRequest::from_bytes(&buf[..size]).unwrap();
             if addr == SocketAddr::V4("127.0.0.1:33445".parse().unwrap()) {
-                let client = peers_cache.get_mut(&bob_pk).unwrap();
+                let client = ping_map.get_mut(&bob_pk).unwrap();
                 let ping_req_payload = ping_req.get_payload(&bob_sk).unwrap();
                 let dur = Duration::from_secs(PING_TIMEOUT);
                 assert!(client.check_ping_id(ping_req_payload.id, dur));
             } else {
-                let client = peers_cache.get_mut(&ping_pk).unwrap();
+                let client = ping_map.get_mut(&ping_pk).unwrap();
                 let ping_req_payload = ping_req.get_payload(&ping_sk).unwrap();
                 let dur = Duration::from_secs(PING_TIMEOUT);
                 assert!(client.check_ping_id(ping_req_payload.id, dur));
@@ -2366,7 +2366,7 @@ mod tests {
              pk: bob_pk,
              saddr: "127.0.0.1:12345".parse().unwrap(),
          };
-         assert!(alice.send_nodes_req(target_node, alice.pk, &mut ClientData::new()).wait().is_ok());
+         assert!(alice.send_nodes_req(target_node, alice.pk, &mut PingData::new()).wait().is_ok());
 
          let node = PackedNode {
              pk: gen_keypair().0,
@@ -2374,7 +2374,7 @@ mod tests {
          };
          alice.try_add_to_close_nodes(&node);
 
-         assert!(alice.send_nodes_req(target_node, alice.pk, &mut ClientData::new()).wait().is_ok());
+         assert!(alice.send_nodes_req(target_node, alice.pk, &mut PingData::new()).wait().is_ok());
      }
 
     // send_nat_ping_req()
@@ -2515,10 +2515,10 @@ mod tests {
         let dur = Duration::from_secs(0);
         alice.remove_timedout_clients(dur).wait().unwrap();
 
-        let peers_cache = alice.peers_cache.read();
+        let ping_map = alice.ping_map.read();
 
         // after client be removed
-        assert!(!peers_cache.contains_key(&bob_pk));
+        assert!(!ping_map.contains_key(&bob_pk));
     }
 
     // remove_timedout_clients(), case of client remained
@@ -2535,11 +2535,11 @@ mod tests {
         let dur = Duration::from_secs(1);
         alice.remove_timedout_clients(dur).wait().unwrap();
 
-        let peers_cache = alice.peers_cache.read();
+        let ping_map = alice.ping_map.read();
         let close_nodes = alice.close_nodes.read();
 
         // client should be remained
-        assert!(peers_cache.contains_key(&bob_pk));
+        assert!(ping_map.contains_key(&bob_pk));
         // peer should be remained in close_nodes
         assert!(close_nodes.contains(&bob_pk));
     }
@@ -2613,7 +2613,7 @@ mod tests {
         alice.set_config_values(args);
         alice.dht_main_loop().wait().unwrap();
 
-        let mut peers_cache = alice.peers_cache.write();
+        let mut ping_map = alice.ping_map.write();
 
         rx.take(2).map(|received| {
             let (packet, addr) = received;
@@ -2621,12 +2621,12 @@ mod tests {
             let (_, size) = packet.to_bytes((&mut buf, 0)).unwrap();
             let (_, nodes_req) = NodesRequest::from_bytes(&buf[..size]).unwrap();
             if addr == SocketAddr::V4("127.0.0.1:33445".parse().unwrap()) {
-                let client = peers_cache.get_mut(&bob_pk).unwrap();
+                let client = ping_map.get_mut(&bob_pk).unwrap();
                 let nodes_req_payload = nodes_req.get_payload(&bob_sk).unwrap();
                 let dur = Duration::from_secs(PING_TIMEOUT);
                 assert!(client.check_ping_id(nodes_req_payload.id, dur));
             } else {
-                let client = peers_cache.get_mut(&ping_pk).unwrap();
+                let client = ping_map.get_mut(&ping_pk).unwrap();
                 let nodes_req_payload = nodes_req.get_payload(&ping_sk).unwrap();
                 let dur = Duration::from_secs(PING_TIMEOUT);
                 assert!(client.check_ping_id(nodes_req_payload.id, dur));
@@ -2657,7 +2657,7 @@ mod tests {
         alice.set_config_values(args);
         alice.dht_main_loop().wait().unwrap();
 
-        let mut peers_cache = alice.peers_cache.write();
+        let mut ping_map = alice.ping_map.write();
 
         rx.take(2).map(|received| {
             let (packet, addr) = received;
@@ -2665,12 +2665,12 @@ mod tests {
             let (_, size) = packet.to_bytes((&mut buf, 0)).unwrap();
             let (_, nodes_req) = NodesRequest::from_bytes(&buf[..size]).unwrap();
             if addr == SocketAddr::V4("127.0.0.1:33445".parse().unwrap()) {
-                let client = peers_cache.get_mut(&bob_pk).unwrap();
+                let client = ping_map.get_mut(&bob_pk).unwrap();
                 let nodes_req_payload = nodes_req.get_payload(&bob_sk).unwrap();
                 let dur = Duration::from_secs(PING_TIMEOUT);
                 assert!(client.check_ping_id(nodes_req_payload.id, dur));
             } else {
-                let client = peers_cache.get_mut(&ping_pk).unwrap();
+                let client = ping_map.get_mut(&ping_pk).unwrap();
                 let nodes_req_payload = nodes_req.get_payload(&ping_sk).unwrap();
                 let dur = Duration::from_secs(PING_TIMEOUT);
                 assert!(client.check_ping_id(nodes_req_payload.id, dur));
@@ -2713,7 +2713,7 @@ mod tests {
         alice.set_config_values(args);
         alice.dht_main_loop().wait().unwrap();
 
-        let mut peers_cache = alice.peers_cache.write();
+        let mut ping_map = alice.ping_map.write();
 
         rx.take(2).map(|received| {
             let (packet, addr) = received;
@@ -2721,12 +2721,12 @@ mod tests {
             let (_, size) = packet.to_bytes((&mut buf, 0)).unwrap();
             let (_, nodes_req) = NodesRequest::from_bytes(&buf[..size]).unwrap();
             if addr == SocketAddr::V4("127.0.0.1:33445".parse().unwrap()) {
-                let client = peers_cache.get_mut(&bob_pk).unwrap();
+                let client = ping_map.get_mut(&bob_pk).unwrap();
                 let nodes_req_payload = nodes_req.get_payload(&bob_sk).unwrap();
                 let dur = Duration::from_secs(PING_TIMEOUT);
                 assert!(client.check_ping_id(nodes_req_payload.id, dur));
             } else {
-                let client = peers_cache.get_mut(&ping_pk).unwrap();
+                let client = ping_map.get_mut(&ping_pk).unwrap();
                 let nodes_req_payload = nodes_req.get_payload(&ping_sk).unwrap();
                 let dur = Duration::from_secs(PING_TIMEOUT);
                 assert!(client.check_ping_id(nodes_req_payload.id, dur));


### PR DESCRIPTION
DhtNode has redundancy in peers_cache.
So, separate ClientData from DhtNode.