### PR TITLE
Do not fall on invalid packets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ nom = "3.2"
 cookie-factory = "0.2.3"
 get_if_addrs = "0.5.1"
 parking_lot = "0.5"
+failure = "0.1"
 
 [dev-dependencies]
 env_logger = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,8 @@ extern crate tokio;
 extern crate tokio_io;
 extern crate get_if_addrs;
 extern crate parking_lot;
+#[macro_use]
+extern crate failure;
 
 #[cfg(test)]
 extern crate tokio_timer;


### PR DESCRIPTION
There are two ways to fix handling of incomplete or broken packet:
1. Encode deserialization error type to `Decoder::Item` and then filter out these error. In this approach we should change `type Item = DhtPacket;` to `type Item = Result<DhtPacket, Err>;` in `impl Decoder for DhtCodec` and return `Ok(Err(...))` in `decode` method in case of failure.
2. Add possibility to match on error types so that we could filter out only deserialization errors. This is  a bit more straightforward approach but requires to change error types. The easiest way to do it is using `failure` crate. It will bring some mess with errors in our code but if we are going to customize our errors it could be a good starting point.

This pull request implements the second way. Thoughts?