### PR TITLE
Simplify dht node

### DIFF
--- a/src/toxcore/dht/daemon_state.rs
+++ b/src/toxcore/dht/daemon_state.rs
@@ -36,8 +36,7 @@ impl DaemonState {
         let close_nodes = server.close_nodes.read();
 
         let nodes = close_nodes.iter()
-            .cloned()
-            .flat_map(|node| node.to_packed_node(server.is_ipv6_enabled()))
+            .flat_map(|node| node.to_packed_node())
             .collect::<Vec<PackedNode>>();
 
         let mut buf = [0u8; DHT_STATE_BUFFER_SIZE];


### PR DESCRIPTION
Changes:
- Since `Bucket` stores only nodes that we can reach `DhtNode` can have IPv6 address only if `is_ipv6_enabled` is `true`. It means that we don't have to pass this variable to `DhtNode` and store it in `Kbucket` anymore. So it was removed.