### PR TITLE
Add limit for TCP connections count

### DIFF
--- a/examples/tcp_server.rs
+++ b/examples/tcp_server.rs
@@ -14,6 +14,8 @@ use tox::toxcore::stats::Stats;
 use tokio::net::TcpListener;
 use futures::Future;
 
+const TCP_CONNECTIONS_LIMIT: usize = 1024;
+
 fn main() {
     env_logger::init();
     // Server constant PK for examples/tests
@@ -34,7 +36,7 @@ fn main() {
     let server = Server::new();
 
     let stats = Stats::new();
-    let future = server.run(listener, server_sk, stats)
+    let future = server.run(listener, server_sk, stats, TCP_CONNECTIONS_LIMIT)
         .map_err(|_| ());
 
     tokio::run(future);

--- a/src/toxcore/tcp/client/client.rs
+++ b/src/toxcore/tcp/client/client.rs
@@ -1137,7 +1137,7 @@ pub mod tests {
 
         let server = Server::new();
         let stats = Stats::new();
-        let server_future = server.run(listener, server_sk, stats)
+        let server_future = server.run(listener, server_sk, stats, 2)
             .map_err(|e| Error::new(ErrorKind::Other, e.compat()));
 
         // run first client

--- a/src/toxcore/tcp/server/server.rs
+++ b/src/toxcore/tcp/server/server.rs
@@ -74,12 +74,6 @@ impl Server {
 
         shutdown_future
     }
-    /** The number of active connections.
-    */
-    pub fn count(&self) -> usize {
-        let state = self.state.read();
-        state.connected_clients.len()
-    }
     /** The main processing function. Call in on each incoming packet from connected and
     handshaked client.
     */
@@ -563,19 +557,6 @@ mod tests {
         let (tx, rx) = mpsc::channel(32);
         let client = Client::new(tx, &client_pk, saddr.ip(), saddr.port());
         (client, rx)
-    }
-
-    #[test]
-    fn count() {
-        crypto_init().unwrap();
-        let server = Server::new();
-
-        assert_eq!(server.count(), 0);
-
-        let (client_1, _rx_1) = create_random_client("1.2.3.4:12345".parse().unwrap());
-        server.insert(client_1).wait().unwrap();
-
-        assert_eq!(server.count(), 1);
     }
 
     #[test]

--- a/src/toxcore/tcp/server/server.rs
+++ b/src/toxcore/tcp/server/server.rs
@@ -74,7 +74,13 @@ impl Server {
 
         shutdown_future
     }
-    /**The main processing function. Call in on each incoming packet from connected and
+    /** The number of active connections.
+    */
+    pub fn count(&self) -> usize {
+        let state = self.state.read();
+        state.connected_clients.len()
+    }
+    /** The main processing function. Call in on each incoming packet from connected and
     handshaked client.
     */
     pub fn handle_packet(&self, pk: &PublicKey, packet: Packet) -> impl Future<Item = (), Error = Error> + Send {
@@ -557,6 +563,19 @@ mod tests {
         let (tx, rx) = mpsc::channel(32);
         let client = Client::new(tx, &client_pk, saddr.ip(), saddr.port());
         (client, rx)
+    }
+
+    #[test]
+    fn count() {
+        crypto_init().unwrap();
+        let server = Server::new();
+
+        assert_eq!(server.count(), 0);
+
+        let (client_1, _rx_1) = create_random_client("1.2.3.4:12345".parse().unwrap());
+        server.insert(client_1).wait().unwrap();
+
+        assert_eq!(server.count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Tested with `ulimit -n 64`, running with limit of 32 connections and spawning with `for i in {1..100}; (netcat localhost 33445 &);`.