### PR TITLE
Refactor timeouts

### DIFF
--- a/src/toxcore/io_tokio.rs
+++ b/src/toxcore/io_tokio.rs
@@ -2,11 +2,8 @@
 
 use std::fmt::Debug;
 use std::io::{Error as IoError};
-use std::time::Duration;
 
 use futures::{Future, Sink, Stream};
-use tokio::util::FutureExt;
-use tokio::timer::timeout::Error as TimeoutError;
 
 /// A convenience typedef around a `Future` whose error component is `io::Error`
 pub type IoFuture<T> = Box<Future<Item = T, Error = IoError> + Send>;
@@ -24,14 +21,6 @@ pub fn send_to<T: Send + 'static, Tx, E: Debug>(tx: &Tx, v: T) -> impl Future<It
         .map(|_tx| ()) // ignore tx because it was cloned
 }
 
-/// Send item to a sink using reference with timeout
-pub fn send_to_bounded<T: Send + 'static, Tx, E: Debug>(tx: &Tx, v: T, timeout: Duration) -> impl Future<Item=(), Error=TimeoutError<E>> + Send
-    where Tx: Sink<SinkItem = T, SinkError = E> + Send + Clone + 'static
-{
-    send_to(tx, v)
-        .timeout(timeout)
-}
-
 /// Send item to a sink using reference
 pub fn send_all_to<T: Send + 'static, S, Tx, E: Debug>(tx: &Tx, s: S) -> impl Future<Item=(), Error=E> + Send
     where S: Stream<Item = T, Error = E> + Send + 'static,
@@ -43,11 +32,3 @@ pub fn send_all_to<T: Send + 'static, S, Tx, E: Debug>(tx: &Tx, s: S) -> impl Fu
         .map(|_tx| ()) // ignore tx because it was cloned
 }
 
-/// Send item to a sink using reference with timeout
-pub fn send_all_to_bounded<T: Send + 'static, S, Tx, E: Debug>(tx: &Tx, s: S, timeout: Duration) -> impl Future<Item=(), Error=TimeoutError<E>> + Send
-    where S: Stream<Item = T, Error = E> + Send + 'static,
-          Tx: Sink<SinkItem = T, SinkError = E> + Send + Clone + 'static
-{
-    send_all_to(tx, s)
-        .timeout(timeout)
-}

--- a/src/toxcore/tcp/server/client.rs
+++ b/src/toxcore/tcp/server/client.rs
@@ -16,6 +16,7 @@ use std::time::{Instant, Duration};
 
 use futures::Future;
 use futures::sync::mpsc;
+use tokio::util::FutureExt;
 
 /// Interval in seconds for sending TCP PingRequest
 pub const TCP_PING_FREQUENCY: u64 = 30;
@@ -128,7 +129,7 @@ impl Client {
     /** Send a packet. This method does not ignore IO error
     */
     fn send(&self, packet: Packet) -> impl Future<Item = (), Error = Error> + Send {
-        send_to_bounded(&self.tx, packet, Duration::from_secs(TCP_SEND_TIMEOUT)).map_err(|e|
+        send_to(&self.tx, packet).timeout(Duration::from_secs(TCP_SEND_TIMEOUT)).map_err(|e|
             Error::new(ErrorKind::Other,
                 format!("Failed to send packet: {:?}", e)
         ))


### PR DESCRIPTION
Get rid of `send_bounded` functions and move timeouts to loops. This gives us:
- Less complicated error types which fixes 2 clippy warnings
- Less timers being initialized which should increase performance a bit.

Also this PR makes timeout all error not critical so they won't terminate the application.