### PR TITLE
migrate to nom5 on PingRequest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ futures = "0.1"
 log = "0.4"
 sodiumoxide = { git = "https://github.com/sodiumoxide/sodiumoxide.git", rev = "baf88e5" }
 nom = "3.2"
+nom5 = { package = "nom", git =  "https://github.com/Geal/nom.git" }
 cookie-factory = "0.2"
 get_if_addrs = "0.5"
 parking_lot = "0.7"

--- a/src/toxcore/crypto_core.rs
+++ b/src/toxcore/crypto_core.rs
@@ -5,6 +5,12 @@ pub use sodiumoxide::crypto::box_::*;
 pub use sodiumoxide::crypto::hash::{sha256, sha512};
 pub use sodiumoxide::crypto::secretbox;
 
+use nom5::{
+    combinator::map_opt,
+    bytes::complete::take,
+    error::ParseError
+};
+
 use byteorder::{ByteOrder, LittleEndian, NativeEndian};
 
 use crate::toxcore::binary_io::*;
@@ -190,6 +196,12 @@ impl FromBytes for PublicKey {
     named!(from_bytes<PublicKey>, map_opt!(take!(PUBLICKEYBYTES), PublicKey::from_slice));
 }
 
+impl FromBytes5 for PublicKey {
+    fn from_bytes5<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) ->IResult5<&'a [u8], PublicKey, E> {
+        map_opt(take(PUBLICKEYBYTES), PublicKey::from_slice)(i)
+    }
+}
+
 /* TODO
 Use the following implementation when https://github.com/TokTok/c-toxcore/issues/1169 is fixed.
 And when most of tox network will send valid PK for fake friends.
@@ -209,6 +221,13 @@ impl FromBytes for SecretKey {
 impl FromBytes for Nonce {
     named!(from_bytes<Nonce>, map_opt!(take!(NONCEBYTES), Nonce::from_slice));
 }
+
+impl FromBytes5 for Nonce {
+    fn from_bytes5<'a, E: ParseError<&'a [u8]>>(i: &'a [u8]) ->IResult5<&'a [u8], Nonce, E> {
+        map_opt(take(NONCEBYTES), Nonce::from_slice)(i)
+    }
+}
+
 
 impl FromBytes for secretbox::Nonce {
     named!(from_bytes<secretbox::Nonce>, map_opt!(take!(secretbox::NONCEBYTES), secretbox::Nonce::from_slice));

--- a/src/toxcore/dht/packet/errors.rs
+++ b/src/toxcore/dht/packet/errors.rs
@@ -33,6 +33,10 @@ impl GetPayloadError {
     pub(crate) fn deserialize(error: NomErrorKind, payload: Vec<u8>) -> GetPayloadError {
         GetPayloadError::from(GetPayloadErrorKind::Deserialize { error, payload })
     }
+
+    pub(crate) fn deserialize5(error: nom5::error::ErrorKind, payload: Vec<u8>) -> GetPayloadError {
+        GetPayloadError::from(GetPayloadErrorKind::Deserialize5 { error, payload })
+    }
 }
 
 impl Fail for GetPayloadError {
@@ -70,6 +74,14 @@ pub enum GetPayloadErrorKind {
     Deserialize {
         /// Parsing error
         error: NomErrorKind,
+        /// Received payload of packet
+        payload: Vec<u8>,
+    },
+    /// Error indicates that decrypted payload of packet can't be parsed, it is for nom 5.
+    #[fail(display = "Deserialize payload error: {:?}, data: {:?}", error, payload)]
+    Deserialize5 {
+        /// Parsing error
+        error: nom5::error::ErrorKind,
         /// Received payload of packet
         payload: Vec<u8>,
     }


### PR DESCRIPTION
Currently, nom 3.2 and nom 5 are used at the same time.