### PR TITLE
refactor: Replace byteorder with std functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 bytes = "0.4"
-byteorder = "1"
 futures = "0.1"
 log = "0.4"
 sodiumoxide = "0.2.3"

--- a/src/toxcore/crypto_core.rs
+++ b/src/toxcore/crypto_core.rs
@@ -5,8 +5,6 @@ pub use sodiumoxide::crypto::box_::*;
 pub use sodiumoxide::crypto::hash::{sha256, sha512};
 pub use sodiumoxide::crypto::secretbox;
 
-use byteorder::{ByteOrder, LittleEndian, NativeEndian};
-
 use crate::toxcore::binary_io::*;
 
 // TODO: check if `#[inline]` is actually useful
@@ -37,7 +35,8 @@ pub fn random_u32() -> u32 {
     trace!("Generating random u32");
     let mut array = [0; 4];
     randombytes_into(&mut array);
-    NativeEndian::read_u32(&array)
+    // The order we use here doesn't matter, we just want random bytes.
+    u32::from_be_bytes(array)
 }
 
 /// Return a random number.
@@ -45,7 +44,8 @@ pub fn random_u64() -> u64 {
     trace!("Generating random u64");
     let mut array = [0; 8];
     randombytes_into(&mut array);
-    NativeEndian::read_u64(&array)
+    // The order we use here doesn't matter, we just want random bytes.
+    u64::from_be_bytes(array)
 }
 
 /// Return a random number.
@@ -178,7 +178,7 @@ pub fn increment_nonce_number(nonce: &mut Nonce, num: u64) {
     let Nonce(ref mut bytes) = *nonce;
     bytes.reverse(); // treat nonce as LE number
     let mut num_bytes = [0; NONCEBYTES];
-    LittleEndian::write_u64(&mut num_bytes, num);
+    num_bytes[..8].copy_from_slice(&u64::to_le_bytes(num));
     ::sodiumoxide::utils::add_le(bytes, &num_bytes).unwrap(); // sizes are equal
     bytes.reverse(); // treat nonce as BE number again
 }

--- a/src/toxcore/dht/packet/crypto_data.rs
+++ b/src/toxcore/dht/packet/crypto_data.rs
@@ -1,8 +1,8 @@
 /*! CryptoData packet
 */
 
-use byteorder::{ByteOrder, BigEndian};
 use nom::{be_u16, be_u32, rest};
+use std::convert::TryInto;
 
 use crate::toxcore::binary_io::*;
 use crate::toxcore::crypto_core::*;
@@ -62,7 +62,7 @@ impl ToBytes for CryptoData {
 impl CryptoData {
     /// Get last two bytes of `Nonce` considering it as BigEndian number.
     pub fn nonce_last_bytes(nonce: Nonce) -> u16 {
-        BigEndian::read_u16(&nonce.as_ref()[NONCEBYTES - 2..])
+        u16::from_be_bytes(nonce.as_ref()[NONCEBYTES - 2..].try_into().unwrap())
     }
     /// Create `CryptoData` from `CryptoDataPayload` encrypting it with
     /// `shared_key`.

--- a/src/toxcore/state_format/old.rs
+++ b/src/toxcore/state_format/old.rs
@@ -2,7 +2,6 @@
 //! better will become available.*
 
 use std::default::Default;
-use byteorder::{ByteOrder, LittleEndian};
 use nom::{le_u16, be_u16, le_u8, le_u32, le_u64, rest};
 
 use crate::toxcore::binary_io::*;
@@ -158,8 +157,7 @@ impl ToBytes for DhtState {
         )?;
 
         let len = (idx - start_idx - 16) as u32;
-        LittleEndian::write_u32(&mut buf[start_idx + 8..], len);
-
+        buf[start_idx + 8..start_idx + 12].copy_from_slice(&u32::to_le_bytes(len));
         Ok((buf, idx))
     }
 }
@@ -571,8 +569,7 @@ impl ToBytes for Section {
         }?;
 
         let len = (idx - start_idx - 8) as u32;
-        LittleEndian::write_u32(&mut buf[start_idx..], len);
-
+        buf[start_idx..start_idx + 4].copy_from_slice(&u32::to_le_bytes(len));
         Ok((buf, idx))
     }
 }


### PR DESCRIPTION
Fixes #388.

This favors the `x::from_yy_bytes` functions instead of using the `byteorder` crate. This crate is removed as a dependency.

There was a single use of `NativeEndian` from `byteorder`, when generating random numbers. This was replaced with a use of `from_be_bytes` instead. This has no semantic differences, but *might* be a bit slower on little endian platforms.

The changes were otherwise straightforward.