### PR TITLE
refactor(stats): Use AtomicU64 instead of locks

### DIFF
--- a/src/toxcore/stats.rs
+++ b/src/toxcore/stats.rs
@@ -23,73 +23,34 @@ impl Stats {
     }
 }
 
-#[cfg(target_pointer_width = "64")]
-#[derive(Default)]
-/// Struct for counting packets on x64 CPU.
-pub struct Counters {
-    /// Incoming packets count for Udp/Tcp
-    incoming: AtomicUsize,
-    /// Outgoing packets count for Udp/Tcp
-    outgoing: AtomicUsize,
-}
-
-#[cfg(not(target_pointer_width = "64"))]
 #[derive(Default)]
 /// Struct for counting packets on non-x64 CPU.
 pub struct Counters {
     /// Incoming packets count for Udp/Tcp
-    incoming: Mutex<u64>,
+    incoming: AtomicU64,
     /// Outgoing packets count for Udp/Tcp
-    outgoing: Mutex<u64>,
+    outgoing: AtomicU64,
 }
 
 impl Counters {
     /// Add 1 to incoming counter
-    #[cfg(target_pointer_width = "64")]
     pub fn increase_incoming(&self) {
         self.incoming.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Add 1 to incoming counter
-    #[cfg(not(target_pointer_width = "64"))]
-    pub fn increase_incoming(&self) {
-        *self.incoming.lock().expect("Can't lock mutex") += 1;
-    }
-
     /// Add 1 to outgoing counter
-    #[cfg(target_pointer_width = "64")]
     pub fn increase_outgoing(&self) {
         self.outgoing.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Add 1 to outgoing counter
-    #[cfg(not(target_pointer_width = "64"))]
-    pub fn increase_outgoing(&self) {
-        *self.outgoing.lock().expect("Can't lock mutex") += 1;
-    }
-
     /// Get incoming counter
-    #[cfg(target_pointer_width = "64")]
     pub fn incoming(&self) -> u64 {
-        self.incoming.load(Ordering::Relaxed) as u64
-    }
-
-    /// Get incoming counter
-    #[cfg(not(target_pointer_width = "64"))]
-    pub fn incoming(&self) -> u64 {
-        *self.incoming.lock().expect("Can't lock mutex")
+        self.incoming.load(Ordering::Relaxed)
     }
 
     /// Get outgoing counter
-    #[cfg(target_pointer_width = "64")]
     pub fn outgoing(&self) -> u64 {
-        self.outgoing.load(Ordering::Relaxed) as u64
-    }
-
-    /// Get outgoing counter
-    #[cfg(not(target_pointer_width = "64"))]
-    pub fn outgoing(&self) -> u64 {
-        *self.outgoing.lock().expect("Can't lock mutex")
+        self.outgoing.load(Ordering::Relaxed)
     }
 }
 

--- a/src/toxcore/stats.rs
+++ b/src/toxcore/stats.rs
@@ -4,10 +4,7 @@ This is used by both Udp codec and Tcp codec.
 */
 
 use std::sync::Arc;
-#[cfg(target_pointer_width = "64")]
-use std::sync::atomic::*;
-#[cfg(not(target_pointer_width = "64"))]
-use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Struct for various counters
 #[derive(Clone, Default)]
@@ -24,7 +21,6 @@ impl Stats {
 }
 
 #[derive(Default)]
-/// Struct for counting packets on non-x64 CPU.
 pub struct Counters {
     /// Incoming packets count for Udp/Tcp
     incoming: AtomicU64,

--- a/src/toxcore/stats.rs
+++ b/src/toxcore/stats.rs
@@ -21,6 +21,7 @@ impl Stats {
 }
 
 #[derive(Default)]
+/// A struct for counting incoming and outgoing packets.
 pub struct Counters {
     /// Incoming packets count for Udp/Tcp
     incoming: AtomicU64,


### PR DESCRIPTION
Fixes #360

Previously, we wanted to use `AtomicUsize` as an atomic type large enough for a 64 bit counter. This meant having two versions of the code, one with atomics, another with locks. With the introduction of `AtomicU64` into stable, we can simply use this type no matter what.

This removes code duplication, and allows us to avoid using locks on platforms with 32 bit usize.