### PR TITLE
refactor(toxcore): Replace intervals as bare `u64`s with `Duration`s

### DIFF
--- a/src/toxcore/dht/dht_friend.rs
+++ b/src/toxcore/dht/dht_friend.rs
@@ -188,7 +188,7 @@ mod tests {
 
         let mut enter = tokio_executor::enter().unwrap();
         let clock = Clock::new_with_now(ConstNow(
-            Instant::now() + Duration::from_secs(BAD_NODE_TIMEOUT + 1)
+            Instant::now() + BAD_NODE_TIMEOUT + Duration::from_secs(1)
         ));
 
         with_default(&clock, &mut enter, |_| {

--- a/src/toxcore/dht/dht_node.rs
+++ b/src/toxcore/dht/dht_node.rs
@@ -14,14 +14,15 @@ use crate::toxcore::dht::kbucket::*;
 use crate::toxcore::dht::packed_node::*;
 use crate::toxcore::time::*;
 
-/// Ping interval in seconds for each node in our lists.
-pub const PING_INTERVAL: u64 = 60;
+/// Ping interval for each node in our lists.
+pub const PING_INTERVAL: Duration = Duration::from_secs(60);
 
-/// The number of seconds for a non responsive node to become bad.
-pub const BAD_NODE_TIMEOUT: u64 = PING_INTERVAL * 2 + 2;
+/// Interval of time for a non responsive node to become bad.
+pub const BAD_NODE_TIMEOUT: Duration = Duration::from_secs(PING_INTERVAL.as_secs() * 2 + 2);
 
 /// The timeout after which a node is discarded completely.
-pub const KILL_NODE_TIMEOUT: u64 = BAD_NODE_TIMEOUT + PING_INTERVAL;
+pub const KILL_NODE_TIMEOUT: Duration = 
+    Duration::from_secs(BAD_NODE_TIMEOUT.as_secs() + PING_INTERVAL.as_secs());
 
 /// Struct conatains SocketAddrs and timestamps for sending and receiving packet
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -55,20 +56,20 @@ impl<T: Into<SocketAddr> + Copy> SockAndTime<T> {
         }
     }
     /// Check if the address is considered bad i.e. it does not answer on
-    /// addresses for `BAD_NODE_TIMEOUT` seconds.
+    /// addresses for `BAD_NODE_TIMEOUT`.
     pub fn is_bad(&self) -> bool {
-        self.last_resp_time.map_or(true, |time| clock_elapsed(time) > Duration::from_secs(BAD_NODE_TIMEOUT))
+        self.last_resp_time.map_or(true, |time| clock_elapsed(time) > BAD_NODE_TIMEOUT)
     }
 
     /// Check if the node is considered discarded i.e. it does not answer on
-    /// addresses for `KILL_NODE_TIMEOUT` seconds.
+    /// addresses for `KILL_NODE_TIMEOUT`.
     pub fn is_discarded(&self) -> bool {
-        self.last_resp_time.map_or(true, |time| clock_elapsed(time) > Duration::from_secs(KILL_NODE_TIMEOUT))
+        self.last_resp_time.map_or(true, |time| clock_elapsed(time) > KILL_NODE_TIMEOUT)
     }
 
     /// Check if `PING_INTERVAL` is passed after last ping request.
     pub fn is_ping_interval_passed(&self) -> bool {
-        self.last_ping_req_time.map_or(true, |time| clock_elapsed(time) >= Duration::from_secs(PING_INTERVAL))
+        self.last_ping_req_time.map_or(true, |time| clock_elapsed(time) >= PING_INTERVAL)
     }
 
     /// Get address if it should be pinged and update `last_ping_req_time`.
@@ -124,7 +125,7 @@ impl DhtNode {
     }
 
     /// Check if the node is considered discarded i.e. it does not answer both
-    /// on IPv4 and IPv6 addresses for `KILL_NODE_TIMEOUT` seconds.
+    /// on IPv4 and IPv6 addresses for `KILL_NODE_TIMEOUT`.
     pub fn is_discarded(&self) -> bool {
         self.assoc4.is_discarded() && self.assoc6.is_discarded()
     }

--- a/src/toxcore/dht/kbucket.rs
+++ b/src/toxcore/dht/kbucket.rs
@@ -477,7 +477,7 @@ mod tests {
 
         let mut enter = tokio_executor::enter().unwrap();
         let clock = Clock::new_with_now(ConstNow(
-            Instant::now() + Duration::from_secs(BAD_NODE_TIMEOUT + 1)
+            Instant::now() + BAD_NODE_TIMEOUT + Duration::from_secs(1)
         ));
 
         // replacing bad node
@@ -505,7 +505,7 @@ mod tests {
 
         let mut enter = tokio_executor::enter().unwrap();
         let clock = Clock::new_with_now(ConstNow(
-            Instant::now() + Duration::from_secs(BAD_NODE_TIMEOUT + 1)
+            Instant::now() + BAD_NODE_TIMEOUT + Duration::from_secs(1)
         ));
 
         // replacing bad node

--- a/src/toxcore/dht/ktree.rs
+++ b/src/toxcore/dht/ktree.rs
@@ -437,7 +437,7 @@ mod tests {
 
         assert!(!ktree.is_all_discarded());
 
-        let time = Instant::now() + Duration::from_secs(KILL_NODE_TIMEOUT + 1);
+        let time = Instant::now() + KILL_NODE_TIMEOUT + Duration::from_secs(1);
 
         let mut enter = tokio_executor::enter().unwrap();
         let clock = Clock::new_with_now(ConstNow(time));

--- a/src/toxcore/dht/lan_discovery.rs
+++ b/src/toxcore/dht/lan_discovery.rs
@@ -46,7 +46,7 @@ pub const START_PORT: u16 = 33446;
 pub const END_PORT: u16 = 33546;
 
 /// Interval in seconds between `LanDiscovery` packet sending.
-pub const LAN_DISCOVERY_INTERVAL: u64 = 10;
+pub const LAN_DISCOVERY_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Shorthand for the transmit half of the message channel.
 type Tx = mpsc::Sender<(Packet, SocketAddr)>;
@@ -143,7 +143,7 @@ impl LanDiscoverySender {
     /// Run LAN discovery periodically. Result future will never be completed
     /// successfully.
     pub fn run(mut self) -> impl Future<Item=(), Error=LanDiscoveryError> + Send {
-        let interval = Duration::from_secs(LAN_DISCOVERY_INTERVAL);
+        let interval = LAN_DISCOVERY_INTERVAL;
         let wakeups = Interval::new(Instant::now(), interval);
         wakeups
             .map_err(|e| e.context(LanDiscoveryErrorKind::Wakeup).into())

--- a/src/toxcore/friend_connection/mod.rs
+++ b/src/toxcore/friend_connection/mod.rs
@@ -55,7 +55,7 @@ const MAIN_LOOP_INTERVAL: Duration = Duration::from_secs(1);
 
 /// After this amount of time with no connection friend's DHT `PublicKey` and IP
 /// address will be considered timed out.
-const FRIEND_DHT_TIMEOUT: Duration = Duration::from_secs(BAD_NODE_TIMEOUT);
+const FRIEND_DHT_TIMEOUT: Duration = BAD_NODE_TIMEOUT;
 
 /// Friend related data stored in the friend connections module.
 #[derive(Clone, Debug)]

--- a/src/toxcore/onion/client/paths_pool.rs
+++ b/src/toxcore/onion/client/paths_pool.rs
@@ -17,13 +17,13 @@ const ONION_PATH_MAX_NO_RESPONSE_USES: u32 = 4;
 pub const NUMBER_ONION_PATHS: usize = 6;
 
 /// Timeout for path we haven't received any response from.
-const ONION_PATH_FIRST_TIMEOUT: u64 = 4;
+const ONION_PATH_FIRST_TIMEOUT: Duration = Duration::from_secs(4);
 
 /// Timeout for path we received at least one response from.
-const ONION_PATH_TIMEOUT: u64 = 10;
+const ONION_PATH_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Maximum time for path being used.
-const ONION_PATH_MAX_LIFETIME: u64 = 1200;
+const ONION_PATH_MAX_LIFETIME: Duration = Duration::from_secs(1200);
 
 /// Onion path that is stored for later usage.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -69,21 +69,21 @@ impl StoredOnionPath {
     /// Check if this path is timed out.
     pub fn is_timed_out(&self) -> bool {
         let timeout = if self.is_new() {
-            Duration::from_secs(ONION_PATH_FIRST_TIMEOUT)
+            ONION_PATH_FIRST_TIMEOUT
         } else {
-            Duration::from_secs(ONION_PATH_TIMEOUT)
+            ONION_PATH_TIMEOUT
         };
 
         self.attempts >= ONION_PATH_MAX_NO_RESPONSE_USES && clock_elapsed(self.last_used) >= timeout ||
-            clock_elapsed(self.creation_time) >= Duration::from_secs(ONION_PATH_MAX_LIFETIME)
+            clock_elapsed(self.creation_time) >= ONION_PATH_MAX_LIFETIME
     }
 
-    /// Path is considered stable after `TIME_TO_STABLE` seconds since it was
+    /// Path is considered stable after `TIME_TO_STABLE` since it was
     /// added to a close list if we receive responses from it.
     pub fn is_stable(&self) -> bool {
-        clock_elapsed(self.creation_time) >= Duration::from_secs(TIME_TO_STABLE) &&
+        clock_elapsed(self.creation_time) >= TIME_TO_STABLE &&
             (self.attempts == 0 ||
-                clock_elapsed(self.last_used) < Duration::from_secs(ONION_PATH_TIMEOUT))
+                clock_elapsed(self.last_used) < ONION_PATH_TIMEOUT)
     }
 
     /// Mark this path each time it was used to send request.

--- a/src/toxcore/onion/onion_announce.rs
+++ b/src/toxcore/onion/onion_announce.rs
@@ -23,9 +23,9 @@ pub const ONION_ANNOUNCE_MAX_ENTRIES: usize = 160;
 /// 2 * `PING_ID_TIMEOUT` seconds.
 pub const PING_ID_TIMEOUT: u64 = 300;
 
-/// Number of seconds that announce entry can be stored in onion announce list
+/// Diration of time thatfor which announce entry can be stored in onion announce list
 /// without re-announcing.
-pub const ONION_ANNOUNCE_TIMEOUT: u64 = 300;
+pub const ONION_ANNOUNCE_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Create onion ping id filled with zeros.
 pub fn initial_ping_id() -> sha256::Digest {
@@ -36,7 +36,7 @@ pub fn initial_ping_id() -> sha256::Digest {
 /** Entry that corresponds to announced onion node.
 
 When node successfully announce itself this entry is added to announced nodes
-list. It's considered expired after `ONION_ANNOUNCE_TIMEOUT` seconds.
+list. It's considered expired after `ONION_ANNOUNCE_TIMEOUT`.
 
 */
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -70,12 +70,12 @@ impl OnionAnnounceEntry {
 
     /** Check if this entry is timed out.
 
-    Entry considered timed out after `ONION_ANNOUNCE_TIMEOUT` seconds since it
+    Entry considered timed out after `ONION_ANNOUNCE_TIMEOUT` since it
     was created.
 
     */
     pub fn is_timed_out(&self) -> bool {
-        clock_elapsed(self.time) >= Duration::from_secs(ONION_ANNOUNCE_TIMEOUT)
+        clock_elapsed(self.time) >= ONION_ANNOUNCE_TIMEOUT
     }
 }
 
@@ -378,7 +378,7 @@ mod tests {
         let mut enter = tokio_executor::enter().unwrap();
         // time when entry is timed out
         let clock = Clock::new_with_now(ConstNow(
-            entry.time + Duration::from_secs(ONION_ANNOUNCE_TIMEOUT + 1)
+            entry.time + ONION_ANNOUNCE_TIMEOUT + Duration::from_secs(1)
         ));
 
         with_default(&clock, &mut enter, |_| {
@@ -476,7 +476,7 @@ mod tests {
         let mut enter = tokio_executor::enter().unwrap();
         // time when entry is timed out
         let clock = Clock::new_with_now(ConstNow(
-            entry_time + Duration::from_secs(ONION_ANNOUNCE_TIMEOUT + 1)
+            entry_time + ONION_ANNOUNCE_TIMEOUT + Duration::from_secs(1)
         ));
 
         with_default(&clock, &mut enter, |_| {
@@ -563,11 +563,11 @@ mod tests {
         let mut enter = tokio_executor::enter().unwrap();
         // time when all entries except one will be created
         let clock_1 = Clock::new_with_now(ConstNow(
-            now + Duration::from_secs(ONION_ANNOUNCE_TIMEOUT)
+            now + ONION_ANNOUNCE_TIMEOUT
         ));
         // time when one entry will be timed out
         let clock_2 = Clock::new_with_now(ConstNow(
-            now + Duration::from_secs(ONION_ANNOUNCE_TIMEOUT + 1)
+            now + ONION_ANNOUNCE_TIMEOUT + Duration::from_secs(1)
         ));
 
         with_default(&clock_1, &mut enter, |_| {

--- a/src/toxcore/tcp/server/client.rs
+++ b/src/toxcore/tcp/server/client.rs
@@ -18,12 +18,12 @@ use futures::Future;
 use futures::sync::mpsc;
 use tokio::util::FutureExt;
 
-/// Interval in seconds for sending TCP PingRequest
-pub const TCP_PING_FREQUENCY: u64 = 30;
-/// Timeout in seconds for waiting response of PingRequest sent
-pub const TCP_PING_TIMEOUT: u64 = 10;
-/// Timeout in seconds for packet sending
-pub const TCP_SEND_TIMEOUT: u64 = 1;
+/// Interval of time for sending TCP PingRequest
+pub const TCP_PING_FREQUENCY: Duration = Duration::from_secs(30);
+/// Interval of time for waiting response of PingRequest sent
+pub const TCP_PING_TIMEOUT: Duration = Duration::from_secs(10);
+/// Interval of time for packet sending
+pub const TCP_SEND_TIMEOUT: Duration = Duration::from_secs(1);
 
 /** Structure that represents how Server keeps connected clients. A write-only socket with
 human interface. A client cannot send a message directly to another client, whereas server can.
@@ -105,13 +105,13 @@ impl Client {
     /** Check if PongResponse timed out
     */
     pub fn is_pong_timedout(&self) -> bool {
-        clock_elapsed(self.last_pong_resp) > Duration::from_secs(TCP_PING_TIMEOUT + TCP_PING_FREQUENCY)
+        clock_elapsed(self.last_pong_resp) > TCP_PING_TIMEOUT + TCP_PING_FREQUENCY
     }
 
     /** Check if Ping interval is elapsed
     */
     pub fn is_ping_interval_passed(&self) -> bool {
-        clock_elapsed(self.last_pinged) >= Duration::from_secs(TCP_PING_FREQUENCY)
+        clock_elapsed(self.last_pinged) >= TCP_PING_FREQUENCY
     }
 
     /** Get the Links of the Client
@@ -129,7 +129,7 @@ impl Client {
     /** Send a packet. This method does not ignore IO error
     */
     fn send(&self, packet: Packet) -> impl Future<Item = (), Error = Error> + Send {
-        send_to(&self.tx, packet).timeout(Duration::from_secs(TCP_SEND_TIMEOUT)).map_err(|e|
+        send_to(&self.tx, packet).timeout(TCP_SEND_TIMEOUT).map_err(|e|
             Error::new(ErrorKind::Other,
                 format!("Failed to send packet: {:?}", e)
         ))

--- a/src/toxcore/tcp/server/server.rs
+++ b/src/toxcore/tcp/server/server.rs
@@ -1649,7 +1649,7 @@ mod tests {
         let mut enter = tokio_executor::enter().unwrap();
         // time when all entries is needed to send PingRequest
         let clock_1 = Clock::new_with_now(ConstNow(
-            now + Duration::from_secs(TCP_PING_FREQUENCY + 1)
+            now + TCP_PING_FREQUENCY + Duration::from_secs(1)
         ));
 
         with_default(&clock_1, &mut enter, |_| {
@@ -1693,7 +1693,7 @@ mod tests {
         let mut enter = tokio_executor::enter().unwrap();
         // time when all entries is timedout and should be removed
         let clock_1 = Clock::new_with_now(ConstNow(
-            now + Duration::from_secs(TCP_PING_FREQUENCY + TCP_PING_TIMEOUT + 1)
+            now + TCP_PING_FREQUENCY + TCP_PING_TIMEOUT + Duration::from_secs(1)
         ));
 
         with_default(&clock_1, &mut enter, |_| {

--- a/src/toxcore/tcp/server/server_ext.rs
+++ b/src/toxcore/tcp/server/server_ext.rs
@@ -22,11 +22,11 @@ use crate::toxcore::tcp::handshake::make_server_handshake;
 use crate::toxcore::tcp::server::{Client, Server};
 use crate::toxcore::stats::*;
 
-/// Interval in seconds for Tcp Ping sender
-const TCP_PING_INTERVAL: u64 = 1;
+/// Interval of time for Tcp Ping sender
+const TCP_PING_INTERVAL: Duration = Duration::from_secs(1);
 
-/// Timeout in seconds for the TCP handshake.
-const TCP_HANDSHAKE_TIMEOUT: u64 = 10;
+/// Interval of time for the TCP handshake.
+const TCP_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 const SERVER_CHANNEL_SIZE: usize = 64;
 
@@ -144,8 +144,7 @@ impl ServerExt for Server {
                 Ok(())
             });
 
-        let interval = Duration::from_secs(TCP_PING_INTERVAL);
-        let wakeups = Interval::new(Instant::now(), interval);
+        let wakeups = Interval::new(Instant::now(), TCP_PING_INTERVAL);
         let ping_future = wakeups
             .map_err(|error| ServerRunError::PingWakeupsError { error })
             .for_each(move |_instant| {
@@ -172,7 +171,7 @@ impl ServerExt for Server {
         debug!("A new TCP client connected from {}", addr);
 
         let register_client = (make_server_handshake(stream, dht_sk.clone()))
-            .timeout(Duration::from_secs(TCP_HANDSHAKE_TIMEOUT))
+            .timeout(TCP_HANDSHAKE_TIMEOUT)
             .map_err(|error| ConnectionError::ServerHandshakeError { error })
             .map(|(stream, channel, client_pk)| {
                 debug!("Handshake for TCP client {:?} is completed", client_pk);
@@ -385,7 +384,7 @@ mod tests {
                             ping_id: 42
                         }));
                         // Set time when the client should be pinged
-                        mut_now_c.set(now + Duration::from_secs(TCP_PING_FREQUENCY + 1));
+                        mut_now_c.set(now + TCP_PING_FREQUENCY + Duration::from_secs(1));
                         from_server_c
                     })
                     .map_err(|(e, _)| Error::from(e))


### PR DESCRIPTION
This prevents misusing them as plain numbers.