### PR TITLE
Use idiomatic sodiumoxide API for password KDF

### DIFF
--- a/tox_crypto/src/lib.rs
+++ b/tox_crypto/src/lib.rs
@@ -6,7 +6,6 @@ pub use sodiumoxide::crypto::hash::{sha256, sha512};
 pub use sodiumoxide::crypto::secretbox;
 
 pub use sodiumoxide::crypto::pwhash;
-pub use sodiumoxide::utils::memzero;
 
 // TODO: check if `#[inline]` is actually useful
 


### PR DESCRIPTION
Uses the sodiumoxide API from the [documentation example](https://docs.rs/sodiumoxide/0.2.5/sodiumoxide/crypto/pwhash/index.html#example-key-derivation) for deriving
a key from a passphrase, and securely zeroing the intermediate key.