### PR TITLE
refactor: remove unnecessary clones and async move blocks

### DIFF
--- a/examples/dht_server.rs
+++ b/examples/dht_server.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Error> {
 
     let stats = Stats::new();
 
-    let lan_discovery_sender =
+    let mut lan_discovery_sender =
         LanDiscoverySender::new(tx.clone(), server_pk, local_addr.is_ipv6());
 
     let mut server = Server::new(tx, server_pk, server_sk);

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Error> {
     let socket = common::bind_socket(local_addr).await;
     let stats = Stats::new();
 
-    let lan_discovery_sender = LanDiscoverySender::new(tx.clone(), dht_pk, local_addr.is_ipv6());
+    let mut lan_discovery_sender = LanDiscoverySender::new(tx.clone(), dht_pk, local_addr.is_ipv6());
 
     let (tcp_incoming_tx, mut tcp_incoming_rx) = mpsc::unbounded();
 
@@ -122,10 +122,9 @@ async fn main() -> Result<(), Error> {
         onion_client.add_path_node(node).await;
     }
 
-    let tcp_connections_c = tcp_connections.clone();
-    let net_crypto_tcp_future = async move {
+    let net_crypto_tcp_future = async {
         while let Some((packet, pk)) = net_crypto_tcp_rx.next().await {
-            tcp_connections_c.send_data(pk, packet).await?;
+            tcp_connections.send_data(pk, packet).await?;
         }
         Result::<(), Error>::Ok(())
     };

--- a/examples/tcp_server.rs
+++ b/examples/tcp_server.rs
@@ -33,7 +33,7 @@ fn main() {
     let server = Server::new();
 
     let stats = Stats::new();
-    let future = async move {
+    let future = async {
         let listener = TcpListener::bind(&addr).await.unwrap();
         drop(tcp_run(&server, listener, server_sk, stats, TCP_CONNECTIONS_LIMIT).await);
     };

--- a/tox_core/src/dht/lan_discovery.rs
+++ b/tox_core/src/dht/lan_discovery.rs
@@ -140,7 +140,7 @@ impl LanDiscoverySender {
 
     /// Run LAN discovery periodically. Result future will never be completed
     /// successfully.
-    pub async fn run(mut self) -> Result<(), LanDiscoveryError> {
+    pub async fn run(&mut self) -> Result<(), LanDiscoveryError> {
         let interval = LAN_DISCOVERY_INTERVAL;
         let mut wakeups = tokio::time::interval(interval);
 

--- a/tox_core/src/onion/client/mod.rs
+++ b/tox_core/src/onion/client/mod.rs
@@ -907,7 +907,7 @@ impl OnionClient {
     }
 
     /// Run periodical announcements and friends searching.
-    pub async fn run(self) -> Result<(), RunError> {
+    pub async fn run(&self) -> Result<(), RunError> {
         let interval = Duration::from_secs(1);
         let mut wakeups = tokio::time::interval(interval);
 

--- a/tox_core/src/relay/client/connections.rs
+++ b/tox_core/src/relay/client/connections.rs
@@ -382,7 +382,7 @@ impl Connections {
 
     /// Run TCP periodical tasks. Result future will never be completed
     /// successfully.
-    pub async fn run(self) -> Result<(), ConnectionError> {
+    pub async fn run(&self) -> Result<(), ConnectionError> {
         let mut wakeups = tokio::time::interval(CONNECTIONS_INTERVAL);
 
         while wakeups.next().await.is_some() {


### PR DESCRIPTION
It became possible after migration to async/await.