### PR TITLE
feat(ktree): implement k-tree with force-k modification

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust:
           - stable
-          - 1.40.0
+          - 1.42.0
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -48,7 +48,7 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
-  
+
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ issue / pull request should be filled on the reference repository.
 [CONTRIBUTING.md](/CONTRIBUTING.md).
 
 ## Building
-Fairly simple. First, install [Rust] >= 1.40.0 and a C compiler ([Build Tools
+Fairly simple. First, install [Rust] >= 1.42.0 and a C compiler ([Build Tools
 for Visual Studio][VSBuild] on Windows, GCC or Clang on other platforms).
 
 Then you can build the debug version with

--- a/tox_core/Cargo.toml
+++ b/tox_core/Cargo.toml
@@ -30,6 +30,7 @@ get_if_addrs = "0.5"
 failure = "0.1"
 lru = "0.6"
 bitflags = "1.0"
+itertools = "0.9"
 
 [dependencies.tokio]
 version = "0.2"

--- a/tox_core/src/dht/mod.rs
+++ b/tox_core/src/dht/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod kbucket;
 pub mod ktree;
+pub mod forced_ktree;
 pub mod codec;
 pub mod server;
 pub mod dht_friend;

--- a/tox_core/src/net_crypto/crypto_connection.rs
+++ b/tox_core/src/net_crypto/crypto_connection.rs
@@ -638,18 +638,12 @@ impl CryptoConnection {
 
     /// Check if the connection is established.
     pub fn is_established(&self) -> bool {
-        match self.status {
-            ConnectionStatus::Established { .. } => true,
-            _ => false,
-        }
+        matches!(self.status, ConnectionStatus::Established { .. })
     }
 
     /// Check if the connection is not confirmed.
     pub fn is_not_confirmed(&self) -> bool {
-        match self.status {
-            ConnectionStatus::NotConfirmed { .. } => true,
-            _ => false,
-        }
+        matches!(self.status, ConnectionStatus::NotConfirmed { .. })
     }
 }
 

--- a/tox_core/src/relay/client/client.rs
+++ b/tox_core/src/relay/client/client.rs
@@ -433,26 +433,17 @@ impl Client {
 
     /// Check if TCP connection to the relay is established.
     pub async fn is_connected(&self) -> bool {
-        match *self.status.read().await {
-            ClientStatus::Connected(_) => true,
-            _ => false,
-        }
+        matches!(*self.status.read().await, ClientStatus::Connected(_))
     }
 
     /// Check if TCP connection to the relay is not established.
     pub async fn is_disconnected(&self) -> bool {
-        match *self.status.read().await {
-            ClientStatus::Disconnected => true,
-            _ => false,
-        }
+        matches!(*self.status.read().await, ClientStatus::Disconnected)
     }
 
     /// Check if TCP connection to the relay is sleeping.
     pub async fn is_sleeping(&self) -> bool {
-        match *self.status.read().await {
-            ClientStatus::Sleeping => true,
-            _ => false,
-        }
+        matches!(*self.status.read().await, ClientStatus::Sleeping)
     }
 
     /// Number of unsuccessful attempts to establish connection to the relay.

--- a/tox_packet/src/toxid.rs
+++ b/tox_packet/src/toxid.rs
@@ -312,13 +312,7 @@ mod tests {
 
     fn test_is_hexdump_uppercase(s: &str) -> bool {
         fn test_is_hexdump_uppercase_b(b: u8) -> bool {
-            if let b'A' ..= b'F' = b {
-                true
-            } else if let b'0' ..= b'9' = b {
-                true
-            } else {
-                false
-            }
+            matches!(b, b'A' ..= b'F') || matches!(b, b'0' ..= b'9')
         }
         s.bytes().all(test_is_hexdump_uppercase_b)
     }


### PR DESCRIPTION
Unlike k-tree it holds additional 8 nodes that are always closest to
own PK. It forces a peer to always accept nodes that are closer than
known ones which improves search time.